### PR TITLE
Align entities with SQL schema and add Milvus config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-README.md
 target/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Interview Radar
+
+This project extracts interview questions from forums, classifies them and stores structured data for later retrieval.  
+The workflow below summarizes how data moves through the system. The details come from `interview_workflow.md`.
+
+## Workflow summary
+
+1. **Crawling** – A scheduled job calls `CrawlerService.fetchAndSaveNewInterviews()` to pull new posts and insert records into the `interview` table with `extracted = FALSE`.
+2. **Question Extraction** – For every unprocessed interview the system invokes the LLM to extract the original questions. New rows are inserted into `extracted_question` and the interview flag is updated.
+3. **Category Classification** – Unclassified questions are batched and sent to the LLM together with the list of available categories. Results are written back via the `question_to_category` table and the question row is marked `categorized = TRUE`.
+4. **Vector Embedding & Candidate Recall** – Classified questions are embedded and searched against the Milvus collection `canonical_question` filtered by category id.
+5. **Canonical Question Decision** – Depending on LLM evaluation the extracted question either reuses an existing canonical form, is skipped or creates a new canonical question. Mapping information is stored in `extracted_question_canonical`.
+6. **Topic Mapping** – Canonical questions without topics trigger another LLM call which either links to an existing topic or creates a new one. Topics may also be embedded and stored in the Milvus `topic_chunk` collection.
+7. **Review & Feedback** – Pending canonical questions and topics are manually reviewed. Actions are logged to `entity_review_log` and approved entries are upserted to Milvus.
+
+The database schema used by this project can be found in [`sql/interview_radar.sql`](sql/interview_radar.sql) and a more detailed description of each step lives in [`interview_workflow.md`](interview_workflow.md).
+
+## Building
+
+The project is a standard Spring Boot application. Use the Maven wrapper to build:
+
+```bash
+./mvnw clean package
+```
+
+A `docker-compose.yml` is included for running a Milvus instance locally.

--- a/src/main/java/com/interviewradar/config/MilvusConfig.java
+++ b/src/main/java/com/interviewradar/config/MilvusConfig.java
@@ -1,0 +1,124 @@
+package com.interviewradar.config;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import io.milvus.param.R;
+import io.milvus.param.collection.*;
+import jakarta.annotation.PostConstruct;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "milvus")
+public class MilvusConfig {
+    private String host = "localhost";
+    private Integer port = 19530;
+    private Integer embeddingDim = 1024;
+
+    @Bean
+    public MilvusServiceClient milvusClient() {
+        ConnectParam param = ConnectParam.newBuilder()
+                .withHost(host)
+                .withPort(port)
+                .build();
+        return new MilvusServiceClient(param);
+    }
+
+    @PostConstruct
+    public void initCollections() {
+        MilvusServiceClient client = milvusClient();
+        createCanonicalQuestionCollection(client);
+        createTopicChunkCollection(client);
+    }
+
+    private void createCanonicalQuestionCollection(MilvusServiceClient client) {
+        HasCollectionParam has = HasCollectionParam.newBuilder()
+                .withCollectionName("canonical_question")
+                .build();
+        R<Boolean> exists = client.hasCollection(has);
+        if (exists != null && Boolean.TRUE.equals(exists.getData())) {
+            return;
+        }
+        FieldType id = FieldType.newBuilder()
+                .withName("id")
+                .withDataType(DataType.Int64)
+                .withPrimaryKey(true)
+                .withAutoID(false)
+                .build();
+        FieldType text = FieldType.newBuilder()
+                .withName("text")
+                .withDataType(DataType.VarChar)
+                .withMaxLength(256)
+                .build();
+        FieldType embedding = FieldType.newBuilder()
+                .withName("question_embedding")
+                .withDataType(DataType.FloatVector)
+                .withDimension(embeddingDim)
+                .build();
+        FieldType catId = FieldType.newBuilder()
+                .withName("category_id")
+                .withDataType(DataType.Int64)
+                .build();
+        FieldType status = FieldType.newBuilder()
+                .withName("status")
+                .withDataType(DataType.Int32)
+                .build();
+        CreateCollectionParam create = CreateCollectionParam.newBuilder()
+                .withCollectionName("canonical_question")
+                .withFieldTypes(Arrays.asList(id, text, embedding, catId, status))
+                .build();
+        client.createCollection(create);
+    }
+
+    private void createTopicChunkCollection(MilvusServiceClient client) {
+        HasCollectionParam has = HasCollectionParam.newBuilder()
+                .withCollectionName("topic_chunk")
+                .build();
+        R<Boolean> exists = client.hasCollection(has);
+        if (exists != null && Boolean.TRUE.equals(exists.getData())) {
+            return;
+        }
+        FieldType chunkId = FieldType.newBuilder()
+                .withName("chunk_id")
+                .withDataType(DataType.Int64)
+                .withPrimaryKey(true)
+                .withAutoID(false)
+                .build();
+        FieldType topicId = FieldType.newBuilder()
+                .withName("topic_id")
+                .withDataType(DataType.Int64)
+                .build();
+        FieldType idx = FieldType.newBuilder()
+                .withName("paragraph_idx")
+                .withDataType(DataType.Int32)
+                .build();
+        FieldType text = FieldType.newBuilder()
+                .withName("chunk_text")
+                .withDataType(DataType.VarChar)
+                .withMaxLength(2048)
+                .build();
+        FieldType embedding = FieldType.newBuilder()
+                .withName("chunk_embedding")
+                .withDataType(DataType.FloatVector)
+                .withDimension(embeddingDim)
+                .build();
+        FieldType catId = FieldType.newBuilder()
+                .withName("category_id")
+                .withDataType(DataType.Int64)
+                .build();
+        FieldType status = FieldType.newBuilder()
+                .withName("status")
+                .withDataType(DataType.Int32)
+                .build();
+        CreateCollectionParam create = CreateCollectionParam.newBuilder()
+                .withCollectionName("topic_chunk")
+                .withFieldTypes(Arrays.asList(chunkId, topicId, idx, text, embedding, catId, status))
+                .build();
+        client.createCollection(create);
+    }
+}

--- a/src/main/java/com/interviewradar/model/entity/CanonicalQuestionEntity.java
+++ b/src/main/java/com/interviewradar/model/entity/CanonicalQuestionEntity.java
@@ -23,8 +23,12 @@ public class CanonicalQuestionEntity {
     @Column(name="text", nullable=false, columnDefinition="TEXT")
     private String text;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CategoryEntity category;
+
     @Column(name="count", nullable=false)
-    private Integer count = 0;
+    private Integer count = 1;
 
     @Column(name="created_at", nullable=false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/interviewradar/model/entity/CategoryEntity.java
+++ b/src/main/java/com/interviewradar/model/entity/CategoryEntity.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Entity
 @Table(name = "category")
@@ -30,4 +31,7 @@ public class CategoryEntity {
 
     @Column(name="updated_at", nullable=false)
     private LocalDateTime updatedAt;
+
+    @ManyToMany(mappedBy = "categories")
+    private Set<ExtractedQuestionEntity> questions;
 }

--- a/src/main/java/com/interviewradar/model/entity/ExtractedQuestionEntity.java
+++ b/src/main/java/com/interviewradar/model/entity/ExtractedQuestionEntity.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.Set;
 
+
 @Entity
 @Table(name = "extracted_question")
 @Data @NoArgsConstructor @AllArgsConstructor @Builder
@@ -36,5 +37,21 @@ public class ExtractedQuestionEntity {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @ManyToMany
+    @JoinTable(
+            name = "question_to_category",
+            joinColumns = @JoinColumn(name = "question_id"),
+            inverseJoinColumns = @JoinColumn(name = "category_id")
+    )
+    private Set<CategoryEntity> categories;
+
+    @ManyToMany
+    @JoinTable(
+            name = "extracted_question_canonical",
+            joinColumns = @JoinColumn(name = "extracted_question_id"),
+            inverseJoinColumns = @JoinColumn(name = "canonical_question_id")
+    )
+    private Set<CanonicalQuestionEntity> canonicalQuestions;
 }
 

--- a/src/main/java/com/interviewradar/model/entity/ReviewLogEntity.java
+++ b/src/main/java/com/interviewradar/model/entity/ReviewLogEntity.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class reviewLogEntity {
+public class ReviewLogEntity {
     @Id @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
 
@@ -32,8 +32,8 @@ public class reviewLogEntity {
     @Column(name="reviewer", nullable=false, length=100)
     private String reviewer;
 
-    @Column(name="comment", columnDefinition="TEXT")
-    private String comment;
+    @Column(name="review_comment", columnDefinition="TEXT")
+    private String reviewComment;
 
     @Column(name="action_time", nullable=false)
     private LocalDateTime actionTime;

--- a/src/main/java/com/interviewradar/model/entity/TopicEntity.java
+++ b/src/main/java/com/interviewradar/model/entity/TopicEntity.java
@@ -30,8 +30,8 @@ public class TopicEntity {
     @Column(name="created_at", nullable=false)
     private LocalDateTime createdAt;
 
-    @Column(name="count", nullable=false)
-    private Integer count = 1;
+    @Column(name="occurrence_count", nullable=false)
+    private Integer occurrenceCount = 0;
 
     @Column(name="updated_at", nullable=false)
     private LocalDateTime updatedAt;

--- a/src/main/java/com/interviewradar/model/repository/CanonicalQuestionRepository.java
+++ b/src/main/java/com/interviewradar/model/repository/CanonicalQuestionRepository.java
@@ -1,0 +1,7 @@
+package com.interviewradar.model.repository;
+
+import com.interviewradar.model.entity.CanonicalQuestionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CanonicalQuestionRepository extends JpaRepository<CanonicalQuestionEntity, Long> {
+}

--- a/src/main/java/com/interviewradar/model/repository/ReviewLogRepository.java
+++ b/src/main/java/com/interviewradar/model/repository/ReviewLogRepository.java
@@ -1,0 +1,7 @@
+package com.interviewradar.model.repository;
+
+import com.interviewradar.model.entity.ReviewLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewLogRepository extends JpaRepository<ReviewLogEntity, Long> {
+}

--- a/src/main/java/com/interviewradar/model/repository/TopicRepository.java
+++ b/src/main/java/com/interviewradar/model/repository/TopicRepository.java
@@ -3,6 +3,6 @@ package com.interviewradar.model.repository;
 import com.interviewradar.model.entity.TopicEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TopictRepository extends JpaRepository<TopicEntity, Long> {
+public interface TopicRepository extends JpaRepository<TopicEntity, Long> {
 
 }

--- a/src/main/java/com/interviewradar/service/ClassificationService.java
+++ b/src/main/java/com/interviewradar/service/ClassificationService.java
@@ -85,7 +85,7 @@ public class ClassificationService {
             for (Long catId : chosen) {
                 categoryRepo.findById(catId).ifPresent(cats::add);
             }
-            q.setClassified(true);
+            q.setCategorized(true);
 
             // 3) 保存
             questionRepo.save(q);

--- a/src/main/java/com/interviewradar/service/InterviewProcessingService.java
+++ b/src/main/java/com/interviewradar/service/InterviewProcessingService.java
@@ -91,7 +91,7 @@ public class InterviewProcessingService {
     private void runClassification() {
         if (!windowOpen.get()) return;
         List<ExtractedQuestionEntity> toClassify = questionRepo.findAll().stream()
-                .filter(q -> !q.isClassified())
+                .filter(q -> !q.getCategorized())
                 .collect(Collectors.toList());
 
         if (toClassify.isEmpty()) return;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,3 +49,8 @@ concurrency:
     extract-tasks: 200    # 提取阶段最大并发
     classify-tasks: 10   # 分类阶段最大并发
 
+milvus:
+    host: localhost
+    port: 19530
+    embedding-dim: 1024
+


### PR DESCRIPTION
## Summary
- sync JPA entities with database schema
- create repositories for new entities
- add Milvus connection/collection initialization
- fix classification flag usage
- document workflow in new README
- expose Milvus settings in `application.yaml`

## Testing
- `mvnw test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f7ca2fee88333a7583f8d89d6ac0d