### PR TITLE
Clean up embedding configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,6 @@
             <artifactId>milvus-sdk-java</artifactId>
             <version>2.5.10</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.openai/openai-java -->
-<!--        <dependency>-->
-<!--            <groupId>com.openai</groupId>-->
-<!--            <artifactId>openai-java</artifactId>-->
-<!--            <version>2.12.0</version>-->
-<!--        </dependency>-->
         <!-- https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-milvus -->
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/src/main/java/com/interviewradar/InterviewRadarApplication.java
+++ b/src/main/java/com/interviewradar/InterviewRadarApplication.java
@@ -4,9 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import dev.langchain4j.openai.spring.AutoConfig;
 
 @EnableConfigurationProperties
-@SpringBootApplication
+@SpringBootApplication(exclude = {AutoConfig.class})
 @ConfigurationPropertiesScan("com.interviewradar.config")
 public class InterviewRadarApplication {
 

--- a/src/main/java/com/interviewradar/config/AliyunEmbeddingConfig.java
+++ b/src/main/java/com/interviewradar/config/AliyunEmbeddingConfig.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 @Data
 @Configuration
 @ConfigurationProperties(prefix = "aliyun.embedding")
-public class EmbeddingConfig {
+public class AliyunEmbeddingConfig {
 
     /**
      * Bound from application.yml → aliyun.embedding.*

--- a/src/main/java/com/interviewradar/config/LangChainConfig.java
+++ b/src/main/java/com/interviewradar/config/LangChainConfig.java
@@ -2,36 +2,32 @@ package com.interviewradar.config;
 
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.Data;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
 
 @Configuration
+@ConfigurationProperties(prefix = "langchain4j.open-ai.chat-model")
+@Data
 public class LangChainConfig {
 
-    @Value("${langchain4j.open-ai.chat-model.api-key}")
-    private String chatApiKey;
-
-    @Value("${langchain4j.open-ai.chat-model.base-url}")
-    private String chatBaseUrl;
-
-    @Value("${langchain4j.open-ai.chat-model.model-name}")
-    private String chatModelName;
-
-    @Value("${langchain4j.open-ai.chat-model.timeout}")
-    private Duration chatTimeout;
+    private String apiKey;
+    private String baseUrl;
+    private String modelName;
+    private Duration timeout;
 
     @Primary
     @Bean
     public ChatModel chatModel() {
         return OpenAiChatModel.builder()
-                .apiKey(chatApiKey)
-                .baseUrl(chatBaseUrl)
-                .modelName(chatModelName)
-                .timeout(chatTimeout)
+                .apiKey(apiKey)
+                .baseUrl(baseUrl)
+                .modelName(modelName)
+                .timeout(timeout)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- merge Aliyun embedding properties and config
- simplify LangChain config for chat model
- exclude starter's auto config to disable default embedding model
- remove commented OpenAI dependency

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68700da438908333a63af53ca3be65d3