### PR TITLE
Add standard question viewer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/interviewradar/controller/StandardQuestionController.java
+++ b/src/main/java/com/interviewradar/controller/StandardQuestionController.java
@@ -1,0 +1,25 @@
+package com.interviewradar.controller;
+
+import com.interviewradar.service.StandardQuestionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/standard-questions")
+public class StandardQuestionController {
+    private final StandardQuestionService standardQuestionService;
+
+    @Autowired
+    public StandardQuestionController(StandardQuestionService standardQuestionService) {
+        this.standardQuestionService = standardQuestionService;
+    }
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("questions", standardQuestionService.findAll());
+        return "standard_questions";
+    }
+}

--- a/src/main/java/com/interviewradar/model/dto/StandardQuestionViewDTO.java
+++ b/src/main/java/com/interviewradar/model/dto/StandardQuestionViewDTO.java
@@ -1,0 +1,24 @@
+package com.interviewradar.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StandardQuestionViewDTO {
+    private Long id;
+    private String questionText;
+    private String status;
+    private Integer usageCount;
+    private LocalDateTime updatedAt;
+    private List<String> categories;
+    private List<String> candidateTexts;
+    private List<String> rawQuestions;
+}

--- a/src/main/java/com/interviewradar/model/repository/RawToStandardMapRepository.java
+++ b/src/main/java/com/interviewradar/model/repository/RawToStandardMapRepository.java
@@ -4,5 +4,8 @@ import com.interviewradar.model.entity.RawToStandardMap;
 import com.interviewradar.model.entity.RawToStandardMapId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RawToStandardMapRepository extends JpaRepository<RawToStandardMap, RawToStandardMapId> {
+    List<RawToStandardMap> findByIdStandardQuestionId(Long standardQuestionId);
 }

--- a/src/main/java/com/interviewradar/model/repository/StandardizationCandidateRepository.java
+++ b/src/main/java/com/interviewradar/model/repository/StandardizationCandidateRepository.java
@@ -23,4 +23,6 @@ public interface StandardizationCandidateRepository extends JpaRepository<Standa
     Optional<StandardizationCandidate> findWithRawQuestionAndCategoriesById(Long id);
 
     Page<StandardizationCandidate> findByDecisionStatus(CandidateDecisionStatus status, Pageable pageable);
+
+    List<StandardizationCandidate> findByMatchedStandardId(Long standardId);
 }

--- a/src/main/java/com/interviewradar/service/StandardQuestionService.java
+++ b/src/main/java/com/interviewradar/service/StandardQuestionService.java
@@ -1,0 +1,61 @@
+package com.interviewradar.service;
+
+import com.interviewradar.model.dto.StandardQuestionViewDTO;
+import com.interviewradar.model.entity.StandardQuestion;
+import com.interviewradar.model.repository.RawToStandardMapRepository;
+import com.interviewradar.model.repository.StandardQuestionCategoryRepository;
+import com.interviewradar.model.repository.StandardQuestionRepository;
+import com.interviewradar.model.repository.StandardizationCandidateRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class StandardQuestionService {
+    private final StandardQuestionRepository questionRepo;
+    private final StandardQuestionCategoryRepository sqCatRepo;
+    private final RawToStandardMapRepository mapRepo;
+    private final StandardizationCandidateRepository candRepo;
+
+    @Autowired
+    public StandardQuestionService(StandardQuestionRepository questionRepo,
+                                   StandardQuestionCategoryRepository sqCatRepo,
+                                   RawToStandardMapRepository mapRepo,
+                                   StandardizationCandidateRepository candRepo) {
+        this.questionRepo = questionRepo;
+        this.sqCatRepo = sqCatRepo;
+        this.mapRepo = mapRepo;
+        this.candRepo = candRepo;
+    }
+
+    public List<StandardQuestionViewDTO> findAll() {
+        List<StandardQuestion> questions = questionRepo.findAll(Sort.by(Sort.Direction.DESC, "usageCount"));
+        return questions.stream().map(q -> {
+            List<String> categories = sqCatRepo.findByStandardQuestionId(q.getId())
+                    .stream()
+                    .map(c -> c.getCategory().getName())
+                    .collect(Collectors.toList());
+            List<String> rawQuestions = mapRepo.findByIdStandardQuestionId(q.getId())
+                    .stream()
+                    .map(m -> m.getRawQuestion().getQuestionText())
+                    .collect(Collectors.toList());
+            List<String> candidates = candRepo.findByMatchedStandardId(q.getId())
+                    .stream()
+                    .map(c -> c.getCandidateText())
+                    .collect(Collectors.toList());
+            return StandardQuestionViewDTO.builder()
+                    .id(q.getId())
+                    .questionText(q.getQuestionText())
+                    .status(q.getStatus().name())
+                    .usageCount(q.getUsageCount())
+                    .updatedAt(q.getUpdatedAt())
+                    .categories(categories)
+                    .candidateTexts(candidates)
+                    .rawQuestions(rawQuestions)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/templates/standard_questions.html
+++ b/src/main/resources/templates/standard_questions.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Standard Questions</title>
+    <style>
+        table {border-collapse: collapse; width: 100%;}
+        th, td {border: 1px solid #ccc; padding: 8px; vertical-align: top;}
+    </style>
+</head>
+<body>
+<h1>Standard Questions</h1>
+<table>
+    <thead>
+    <tr>
+        <th>Question</th>
+        <th>Status</th>
+        <th>Usage Count</th>
+        <th>最近考察时间</th>
+        <th>Categories</th>
+        <th>Standardization Candidates</th>
+        <th>Raw Questions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="q : ${questions}">
+        <td th:text="${q.questionText}"></td>
+        <td th:text="${q.status}"></td>
+        <td th:text="${q.usageCount}"></td>
+        <td th:text="${#temporals.format(q.updatedAt, 'yyyy-MM-dd HH:mm')}"></td>
+        <td>
+            <ul>
+                <li th:each="c : ${q.categories}" th:text="${c}"></li>
+            </ul>
+        </td>
+        <td>
+            <ul>
+                <li th:each="c : ${q.candidateTexts}" th:text="${c}"></li>
+            </ul>
+        </td>
+        <td>
+            <ul>
+                <li th:each="r : ${q.rawQuestions}" th:text="${r}"></li>
+            </ul>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add thymeleaf dependency
- support fetching related data for StandardQuestion
- implement service and controller
- create HTML template for listing questions

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687e04e4fb34833389b35bce475b478e